### PR TITLE
Fix the issue of creating new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,3 @@
-<!--
--*- coding: utf-8 -*-
-SPDX-FileCopyrightText: PyPSA-SPICE Developers
-SPDX-License-Identifier: GPL-2.0-or-later
--->
-
 ---
 name: Bug report
 about: Report a bug to help us improve

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,3 @@
-<!--
--*- coding: utf-8 -*-
-SPDX-FileCopyrightText: PyPSA-SPICE Developers
-SPDX-License-Identifier: GPL-2.0-or-later
--->
-
 ---
 name: Feature request
 about: Suggest a new idea or improvement


### PR DESCRIPTION
**Description**
This PR fixes the GitHub issue templates so they now appear correctly when creating a new issue.


**Changes**
GitHub requires the YAML metadata block (the section that defines `name`, `about`, `title`, `labels`, and `assignees`) to appear as the first element in the file so it can correctly parse the template configuration.

The file copyright and encoding comment headers before the `---` block caused GitHub to treat the files as plain Markdown rather than valid issue templates.