### PR TITLE
fix missing date in release note

### DIFF
--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,4 +1,4 @@
-## v1.0.0 (2026-01-DD)
+## v1.0.0 (2026-01-19)
 
 This is the first tagged release of PyPSA-SPICE :partying_face: and represents a complete, fully functional implementation of the model. It establishes the baseline for all future development and includes the core model formulation, execution and post-analysis workflows, the scenario configuration system, and comprehensive documentation.
 


### PR DESCRIPTION
## Changes

Small fix to add missing date in release note for v1.0.0

## Checklist

- [X] Code changes are documented (docstrings for new/modified functions; non-obvious logic, assumptions, or workflow changes documented in `docs/` where relevant).
- [X] A release note entry for this PR has been added to `docs/releases/index.md` for the upcoming release, following the prescribed format.
- [X] I consent to the release of this PR’s code under the `GPL-2.0` license.
