### PR TITLE
Use right stacked column chart display in pypsa-spice-vis

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -6,6 +6,7 @@
 - Add minimum curtailment support via a curtailment penalty in the optimisation objective.
 
 ### Fixed
+- Fix correct barmode in plotly to display right stacked column charts. ([:material-source-pull:111](https://github.com/agoenergy/pypsa-spice/pull/111) by @RichChang963)
 - Change website link display. ([:material-source-pull:110](https://github.com/agoenergy/pypsa-spice/pull/110) by @RichChang963)
 - Fix error handling of missing p_max_pu for generators and links. ([:material-source-pull:107](https://github.com/agoenergy/pypsa-spice/pull/107) by @RichChang963)
 

--- a/pypsa-spice-vis/scripts/plot_functions.py
+++ b/pypsa-spice-vis/scripts/plot_functions.py
@@ -197,7 +197,7 @@ def plot_simple_bar_yearly(
         barmode=(
             "group"
             if graph_config.get("table_name") == "pow_bats_ep_ratio"
-            else "stack"
+            else "relative"
         ),
         color_discrete_map=colour_mapping,
     )

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1500,7 +1500,7 @@ def plot_table(
 
         # Update layout properties
         fig.update_layout(
-            barmode="stack",
+            barmode="relative",
             autosize=False,
             plot_bgcolor=agora_style["figure_edgecolor"],
             paper_bgcolor=agora_style["figure_facecolor"],


### PR DESCRIPTION
Closes #111

## Changes

Change `barmode=relative` to ensure that it follows the default mode (correct way) to display stacked column charts.

## Checklist

- [x] Code changes are documented (docstrings for new/modified functions; non-obvious logic, assumptions, or workflow changes documented in `docs/` where relevant).
- [x] A release note entry for this PR has been added to `docs/releases/index.md` for the upcoming release, following the prescribed format.
- [x] I consent to the release of this PR’s code under the `GPL-2.0` license.
