### PR TITLE
remove polyfill package in mkdocs.yaml

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -6,6 +6,7 @@
 - Add minimum curtailment support via a curtailment penalty in the optimisation objective.
 
 ### Fixed
+- Remove polyfill package to enhance website security. ([:material-source-pull:113](https://github.com/agoenergy/pypsa-spice/pull/113) by @RichChang963)
 - Fix correct barmode in plotly to display right stacked column charts. ([:material-source-pull:111](https://github.com/agoenergy/pypsa-spice/pull/111) by @RichChang963)
 - Change website link display. ([:material-source-pull:110](https://github.com/agoenergy/pypsa-spice/pull/110) by @RichChang963)
 - Fix error handling of missing p_max_pu for generators and links. ([:material-source-pull:107](https://github.com/agoenergy/pypsa-spice/pull/107) by @RichChang963)

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -184,9 +184,6 @@ extra:
 extra_css:
   - "assets/css/custom.css"
 
-extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
-
 plugins:
   - search
   - awesome-pages


### PR DESCRIPTION
Closes #113

## Changes

Remove polyfill used in extra_javascript in mkdocs since it's deprecated and will affect the security of the documentation website.

## Checklist

- [x] Code changes are documented (docstrings for new/modified functions; non-obvious logic, assumptions, or workflow changes documented in `docs/` where relevant).
- [x] A release note entry for this PR has been added to `docs/releases/index.md` for the upcoming release, following the prescribed format.
- [x] I consent to the release of this PR’s code under the `GPL-2.0` license.
